### PR TITLE
Math typo: remove extra $\bar{X}^2$ term

### DIFF
--- a/lectures/lecture12.Rmd
+++ b/lectures/lecture12.Rmd
@@ -175,7 +175,7 @@ where $C_x^2 = \frac{S_x^2}{\bar X^2}$, $C_y^2 = \frac{S_y^2}{\bar Y^2}$, $C_{xy
 * (A) Estimate mean via $\hat \bar Y = r \bar X$ versus (B) Standard mean estimator $\bar y$
 * Under SRS, we have
 $$
-V(\hat \bar Y_{R}) \approx \frac{1-f}{n \bar X^2} \left[ S_y^2  + R^2 S_x^2 - 2 R S_{xy} \right] \bar X^2
+V(\hat \bar Y_{R}) \approx \frac{1-f}{n \bar X^2} \left[ S_y^2  + R^2 S_x^2 - 2 R S_{xy} \right]
 $$
 * Hence, $V(\bar y ) > V(\hat \bar Y_{R})$ if $2 R S_{xy} - R^2 S_x^2 >0$, i.e., 
 $$


### PR DESCRIPTION
The term $(\bar{X}^2)$ seem to have been accidentally included in the numerator. Removing it gives the equivalent of the formula from Cochran (6.5) and what was written on the whiteboard in-class.