### PR TITLE
Add missing exponent in variance approximation formula

### DIFF
--- a/lectures/lecture12.Rmd
+++ b/lectures/lecture12.Rmd
@@ -135,14 +135,14 @@ g_l = \sum_{i=1}^k u_i \frac{\partial g}{\partial u_i} \mid_{u_i=U_i} = \frac{\b
 $$
 Then we have
 $$
-V(r) \approx V(g_l) = \frac{1}{\bar X} \left[ V(\bar y) + R^2 V(\bar x) - 2 R C(\bar x, \bar y) \right]
+V(r) \approx V(g_l) = \frac{1}{\bar X^2} \left[ V(\bar y) + R^2 V(\bar x) - 2 R C(\bar x, \bar y) \right]
 $$
 
 ## Under SRS
 
 $$
 \begin{aligned}
-V(r) &\approx \frac{1}{\bar X} \left[ \frac{1-f}{n} S_y^2 + \frac{1-f}{n} R^2 S_x^2 - \frac{2(1-f)}{n} R S_{xy} \right] \\
+V(r) &\approx \frac{1}{\bar X^2} \left[ \frac{1-f}{n} S_y^2 + \frac{1-f}{n} R^2 S_x^2 - \frac{2(1-f)}{n} R S_{xy} \right] \\
 &= \frac{1-f}{n \bar X^2} \left[ S_y^2 - R^2 S_x^2 - 2 R S_{xy} \right]
 \end{aligned}
 $$


### PR DESCRIPTION
This seems like just a simple typo. With this update, the approximation would match that given in Homework 3.

Update 1:
![Lecture 12, Slide 9](https://user-images.githubusercontent.com/19809917/75099279-c6a9fc00-558d-11ea-8658-b176a84e97f5.png)

Update 2:
![Lecture 12, Slide 10](https://user-images.githubusercontent.com/19809917/75099278-c6a9fc00-558d-11ea-8423-d9e1fef2e207.png)
